### PR TITLE
Wrap PaymentCard hero in Material to stop overlay text warning

### DIFF
--- a/lib/feature/home/presentation/widget/card_list_widget.dart
+++ b/lib/feature/home/presentation/widget/card_list_widget.dart
@@ -92,9 +92,12 @@ class _CardStackPageState extends State<CardStackPage>
                   right: 0,
                   child: Hero(
                     tag: 'card-${cards[index].last4Digits}',
-                    child: PaymentCardWidget(
-                      key: ValueKey(cards[index].last4Digits),
-                      card: cards[index],
+                    child: Material(
+                      type: MaterialType.transparency,
+                      child: PaymentCardWidget(
+                        key: ValueKey(cards[index].last4Digits),
+                        card: cards[index],
+                      ),
                     ),
                   ),
                 );
@@ -223,12 +226,15 @@ class _CardOverlay extends StatelessWidget {
                   },
                   child: Hero(
                     tag: 'card-${cards[index].last4Digits}',
-                    child: PaymentCardWidget(
-                      card: cards[index],
-                      onTap: () {
-                        onSelect(index);
-                        Navigator.of(context).pop();
-                      },
+                    child: Material(
+                      type: MaterialType.transparency,
+                      child: PaymentCardWidget(
+                        card: cards[index],
+                        onTap: () {
+                          onSelect(index);
+                          Navigator.of(context).pop();
+                        },
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- wrap card hero widgets in a transparent Material so text has a scaffold during HeroDialogRoute transition

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892e219eb3483258e056a0d25a979f1