### PR TITLE
Add webview payment demo

### DIFF
--- a/assets/html/payment_demo.html
+++ b/assets/html/payment_demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Payment Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding:20px; }
+    button { padding:10px 20px; margin:5px; font-size:16px; }
+  </style>
+</head>
+<body>
+  <h1>결제 데모 페이지</h1>
+  <button onclick="location.href='paymentdemo://success'">결제 성공</button>
+  <button onclick="location.href='paymentdemo://failure?message=결제%20실패'">결제 실패</button>
+</body>
+</html>

--- a/lib/core/router/go_router.dart
+++ b/lib/core/router/go_router.dart
@@ -11,6 +11,8 @@ import 'package:payment_demo/feature/card_scan/presentation/card_scan_screen.dar
 import 'package:payment_demo/feature/home/presentation/home_screen.dart';
 import 'package:payment_demo/feature/native/native_screen.dart';
 import 'package:payment_demo/feature/splash/splash.dart';
+import 'package:payment_demo/feature/payment/presentation/payment_webview_screen.dart';
+import 'package:payment_demo/feature/payment/presentation/payment_success_screen.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 final GlobalKey<NavigatorState> shellNavigatorKey = GlobalKey<NavigatorState>();
@@ -114,6 +116,24 @@ abstract class GoRouterModule {
             pageBuilder: (context, state) => buildFadeTransitionPage(
               state: state,
               child: const BatteryScreen(),
+            ),
+          ),
+          GoRoute(
+            path: RoutePath.payment,
+            name: RoutePath.payment,
+            builder: (context, state) => const PaymentWebViewScreen(),
+            pageBuilder: (context, state) => buildFadeTransitionPage(
+              state: state,
+              child: const PaymentWebViewScreen(),
+            ),
+          ),
+          GoRoute(
+            path: RoutePath.paymentSuccess,
+            name: RoutePath.paymentSuccess,
+            builder: (context, state) => const PaymentSuccessScreen(),
+            pageBuilder: (context, state) => buildFadeTransitionPage(
+              state: state,
+              child: const PaymentSuccessScreen(),
             ),
           ),
         ],

--- a/lib/core/router/route_path.dart
+++ b/lib/core/router/route_path.dart
@@ -8,4 +8,6 @@ abstract class RoutePath {
   static const String cardInfoInput = 'cardInfoInput';
   static const String native = 'native';
   static const String toss = 'toss';
+  static const String payment = 'payment';
+  static const String paymentSuccess = 'paymentSuccess';
 }

--- a/lib/feature/home/presentation/home_screen.dart
+++ b/lib/feature/home/presentation/home_screen.dart
@@ -72,6 +72,10 @@ class HomeScreen extends BaseScreen with UserState {
           ),
 
           const _BenefitButton(),
+          TextButton(
+            onPressed: () => context.pushNamed(RoutePath.payment),
+            child: const Text('결제 데모 열기'),
+          ),
         ],
       ),
     );

--- a/lib/feature/payment/presentation/payment_success_screen.dart
+++ b/lib/feature/payment/presentation/payment_success_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:payment_demo/core/router/route_path.dart';
+
+class PaymentSuccessScreen extends StatelessWidget {
+  const PaymentSuccessScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('결제 완료')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.check_circle_outline,
+                color: Colors.green, size: 80),
+            const SizedBox(height: 16),
+            const Text('결제가 성공적으로 완료되었습니다.'),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => context.goNamed(RoutePath.home),
+              child: const Text('홈으로 이동'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/payment/presentation/payment_webview_screen.dart
+++ b/lib/feature/payment/presentation/payment_webview_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:go_router/go_router.dart';
+import 'package:payment_demo/core/router/route_path.dart';
+
+class PaymentWebViewScreen extends StatefulWidget {
+  const PaymentWebViewScreen({super.key});
+
+  @override
+  State<PaymentWebViewScreen> createState() => _PaymentWebViewScreenState();
+}
+
+class _PaymentWebViewScreenState extends State<PaymentWebViewScreen> {
+  InAppWebViewController? _controller;
+  String? _htmlData;
+
+  @override
+  void initState() {
+    super.initState();
+    rootBundle.loadString('assets/html/payment_demo.html').then((value) {
+      setState(() {
+        _htmlData = value;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('결제 페이지')),
+      body: _htmlData == null
+          ? const Center(child: CircularProgressIndicator())
+          : InAppWebView(
+              initialSettings: InAppWebViewSettings(
+                javaScriptEnabled: true,
+                incognito: true,
+                useShouldOverrideUrlLoading: true,
+              ),
+              initialData: InAppWebViewInitialData(data: _htmlData!),
+              onWebViewCreated: (controller) => _controller = controller,
+              shouldOverrideUrlLoading: (controller, navigationAction) async {
+                final uri = navigationAction.request.url;
+                if (uri == null) {
+                  return NavigationActionPolicy.ALLOW;
+                }
+                if (uri.scheme == 'paymentdemo') {
+                  switch (uri.host) {
+                    case 'success':
+                      if (mounted) {
+                        context.goNamed(RoutePath.paymentSuccess);
+                      }
+                      break;
+                    case 'failure':
+                      final message =
+                          uri.queryParameters['message'] ?? '결제에 실패했습니다.';
+                      if (mounted) {
+                        showDialog<void>(
+                          context: context,
+                          builder: (context) => AlertDialog(
+                            title: const Text('결제 실패'),
+                            content: Text(message),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.of(context).pop(),
+                                child: const Text('확인'),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+                      break;
+                  }
+                  return NavigationActionPolicy.CANCEL;
+                }
+                return NavigationActionPolicy.ALLOW;
+              },
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   path: ^1.9.1
   image: ^4.5.4
   tosspayments_widget_sdk_flutter: ^2.1.1
+  flutter_inappwebview: ^5.8.0
 
 dev_dependencies:
   flutter_test:
@@ -56,6 +57,7 @@ flutter:
     - assets/images/
     - assets/images/illust/3d/
     - assets/fonts/
+    - assets/html/
 
   fonts:
     - family: Pretendard


### PR DESCRIPTION
## Summary
- integrate flutter_inappwebview with local HTML to simulate payment flow
- add routes and screens for payment page and success redirect
- add demo button on home screen to open the payment webview

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a459db6b5883259ebe34cfbe7214cf