### PR TITLE
Show payment info on success page

### DIFF
--- a/assets/html/payment_demo.html
+++ b/assets/html/payment_demo.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <h1>결제 데모 페이지</h1>
-  <button onclick="location.href='paymentdemo://success'">결제 성공</button>
+  <button onclick="location.href='paymentdemo://success?price=10000&card=visa'">결제 성공</button>
   <button onclick="location.href='paymentdemo://failure?message=결제%20실패'">결제 실패</button>
 </body>
 </html>

--- a/lib/core/router/go_router.dart
+++ b/lib/core/router/go_router.dart
@@ -130,10 +130,17 @@ abstract class GoRouterModule {
           GoRoute(
             path: RoutePath.paymentSuccess,
             name: RoutePath.paymentSuccess,
-            builder: (context, state) => const PaymentSuccessScreen(),
+            builder: (context, state) {
+              final price = state.uri.queryParameters['price'];
+              final card = state.uri.queryParameters['card'];
+              return PaymentSuccessScreen(price: price, card: card);
+            },
             pageBuilder: (context, state) => buildFadeTransitionPage(
               state: state,
-              child: const PaymentSuccessScreen(),
+              child: PaymentSuccessScreen(
+                price: state.uri.queryParameters['price'],
+                card: state.uri.queryParameters['card'],
+              ),
             ),
           ),
         ],

--- a/lib/feature/payment/presentation/payment_success_screen.dart
+++ b/lib/feature/payment/presentation/payment_success_screen.dart
@@ -3,7 +3,10 @@ import 'package:go_router/go_router.dart';
 import 'package:payment_demo/core/router/route_path.dart';
 
 class PaymentSuccessScreen extends StatelessWidget {
-  const PaymentSuccessScreen({super.key});
+  final String? price;
+  final String? card;
+
+  const PaymentSuccessScreen({super.key, this.price, this.card});
 
   @override
   Widget build(BuildContext context) {
@@ -17,6 +20,8 @@ class PaymentSuccessScreen extends StatelessWidget {
                 color: Colors.green, size: 80),
             const SizedBox(height: 16),
             const Text('결제가 성공적으로 완료되었습니다.'),
+            if (price != null) Text('결제 금액: $price'),
+            if (card != null) Text('카드 정보: $card'),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => context.goNamed(RoutePath.home),

--- a/lib/feature/payment/presentation/payment_webview_screen.dart
+++ b/lib/feature/payment/presentation/payment_webview_screen.dart
@@ -48,7 +48,10 @@ class _PaymentWebViewScreenState extends State<PaymentWebViewScreen> {
                   switch (uri.host) {
                     case 'success':
                       if (mounted) {
-                        context.goNamed(RoutePath.paymentSuccess);
+                        context.goNamed(
+                          RoutePath.paymentSuccess,
+                          queryParameters: uri.queryParameters,
+                        );
                       }
                       break;
                     case 'failure':


### PR DESCRIPTION
## Summary
- pass payment success details from WebView redirect to success screen
- display price and card information on payment success screen
- include sample query parameters in payment demo HTML

## Testing
- `dart format lib/feature/payment/presentation/payment_webview_screen.dart lib/feature/payment/presentation/payment_success_screen.dart lib/core/router/go_router.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*
- `dart test` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a45d68b0ec8325b4137b53cbd452fa