### PR TITLE
feat: add basic runtime translation

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1,0 +1,7 @@
+{
+  "home_my_reservation": "My Reservation",
+  "home_tour_pass": "Tour Pass",
+  "home_user_guide": "User Guide",
+  "home_view_card_benefits": "View Card Benefits",
+  "home_open_payment_demo": "Open Payment Demo"
+}

--- a/assets/lang/th.json
+++ b/assets/lang/th.json
@@ -1,0 +1,7 @@
+{
+  "home_my_reservation": "การจองของฉัน",
+  "home_tour_pass": "บัตรท่องเที่ยว",
+  "home_user_guide": "คู่มือการใช้งาน",
+  "home_view_card_benefits": "ดูสิทธิประโยชน์บัตร",
+  "home_open_payment_demo": "เปิดการสาธิตการชำระเงิน"
+}

--- a/assets/lang/zh.json
+++ b/assets/lang/zh.json
@@ -1,0 +1,7 @@
+{
+  "home_my_reservation": "\u6211\u7684\u9884\u7ea6",
+  "home_tour_pass": "\u65c5\u6e38\u901a\u884c\u8bc1",
+  "home_user_guide": "\u4f7f\u7528\u6307\u5357",
+  "home_view_card_benefits": "\u67e5\u770b\u5361\u7247\u4f18\u60e0",
+  "home_open_payment_demo": "\u6253\u5f00\u4ed8\u6b3e\u6f14\u793a"
+}

--- a/lib/common/provider/language_provider.dart
+++ b/lib/common/provider/language_provider.dart
@@ -1,0 +1,29 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:payment_demo/core/util/language_util.dart';
+import 'package:payment_demo/core/util/shared_pref_util.dart';
+import 'package:payment_demo/environment/getit.dart';
+
+/// Riverpod provider to handle the current language of the app.
+final languageProvider =
+    StateNotifierProvider<LanguageNotifier, String>((ref) => LanguageNotifier());
+
+class LanguageNotifier extends StateNotifier<String> {
+  LanguageNotifier() : super('en') {
+    _init();
+  }
+
+  final SharedPrefUtil _pref = locator<SharedPrefUtil>();
+
+  Future<void> _init() async {
+    final saved = _pref.getString('language');
+    state = saved ?? 'en';
+    await LanguageUtil.load(state);
+  }
+
+  Future<void> setLanguage(String code) async {
+    if (state == code) return;
+    state = code;
+    await _pref.setString(key: 'language', value: code);
+    await LanguageUtil.load(code);
+  }
+}

--- a/lib/core/util/language_util.dart
+++ b/lib/core/util/language_util.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+/// A simple utility to load and retrieve localized strings from JSON files.
+class LanguageUtil {
+  LanguageUtil._();
+
+  static Map<String, dynamic> _localizedStrings = {};
+
+  /// Load language JSON from assets. Expected files are placed under
+  /// `assets/lang/` directory.
+  static Future<void> load(String languageCode) async {
+    final jsonString =
+        await rootBundle.loadString('assets/lang/' + languageCode + '.json');
+    _localizedStrings = json.decode(jsonString) as Map<String, dynamic>;
+  }
+
+  /// Get the translated string for [key]. If the key doesn't exist, the key
+  /// itself is returned.
+  static String getString(String key) {
+    return _localizedStrings[key] ?? key;
+  }
+}

--- a/lib/feature/home/presentation/home_screen.dart
+++ b/lib/feature/home/presentation/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:payment_demo/common/domain/entities/user_entity.dart';
+import 'package:payment_demo/common/provider/language_provider.dart';
 import 'package:payment_demo/common/provider/state/user_state.dart';
 import 'package:payment_demo/common/widget/base/base_screen.dart';
 import 'package:payment_demo/common/widget/card_widget.dart';
@@ -10,6 +11,7 @@ import 'package:payment_demo/core/router/route_path.dart';
 import 'package:payment_demo/core/theme/color_style.dart';
 import 'package:payment_demo/core/theme/text_style.dart';
 import 'package:payment_demo/core/constant/png_image_path.dart';
+import 'package:payment_demo/core/util/language_util.dart';
 import 'package:payment_demo/feature/home/presentation/wallet.dart';
 import 'package:payment_demo/feature/home/presentation/widget/card_list_widget.dart';
 import 'package:payment_demo/feature/home/presentation/widget/card_register_widget.dart';
@@ -24,6 +26,7 @@ class HomeScreen extends BaseScreen with UserState {
 
   @override
   Widget buildScreen(BuildContext context, WidgetRef ref) {
+    ref.watch(languageProvider);
     final UserEntity user = getUser(ref);
     return SingleChildScrollView(
       child: Column(
@@ -54,19 +57,19 @@ class HomeScreen extends BaseScreen with UserState {
             ),
           const CardStackPage(),
 
-          const Row(
+          Row(
             spacing: 12,
             children: [
               _HomeMenuButton(
-                label: '내 예약',
+                label: LanguageUtil.getString('home_my_reservation'),
                 imagePath: PngImagePath.payInteraction3d,
               ),
               _HomeMenuButton(
-                label: '관광패스',
+                label: LanguageUtil.getString('home_tour_pass'),
                 imagePath: PngImagePath.wallet3d,
               ),
               _HomeMenuButton(
-                label: '이용안내',
+                label: LanguageUtil.getString('home_user_guide'),
                 imagePath: PngImagePath.cardHand3d,
               ),
             ],
@@ -75,7 +78,7 @@ class HomeScreen extends BaseScreen with UserState {
           const _BenefitButton(),
           TextButton(
             onPressed: () => context.pushNamed(RoutePath.payment),
-            child: const Text('결제 데모 열기'),
+            child: Text(LanguageUtil.getString('home_open_payment_demo')),
           ),
           SizedBox(
             height: 420,
@@ -167,7 +170,7 @@ class _BenefitButton extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              '카드 혜택 정보 보기',
+              LanguageUtil.getString('home_view_card_benefits'),
               style: const TextStyle().subTitle5,
             ),
             const Icon(Icons.chevron_right_rounded),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:payment_demo/core/util/provider_logger.dart';
+import 'package:payment_demo/core/util/language_util.dart';
 import 'package:payment_demo/environment/app_builder.dart';
 import 'package:payment_demo/environment/getit.dart';
 
 void main() async {
   await AppBuilder.init();
+  await LanguageUtil.load('en');
   runApp(
     ProviderScope(
       observers: [ProviderLogger()],
@@ -28,6 +31,16 @@ class MainApp extends StatelessWidget {
         return MaterialApp.router(
           debugShowCheckedModeBanner: false,
           routerConfig: locator<GoRouter>(),
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('en'),
+            Locale('zh'),
+            Locale('th'),
+          ],
           builder: (context, child) {
             return MediaQuery(
               data: MediaQuery.of(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_dotenv: ^5.2.1
   flutter_hooks: ^0.21.2
   flutter_scroll_shadow: ^1.2.6
@@ -63,6 +65,7 @@ flutter:
     - assets/images/illust/3d/
     - assets/fonts/
     - assets/html/
+    - assets/lang/
 
   fonts:
     - family: Pretendard


### PR DESCRIPTION
## Summary
- add flutter_localizations and language assets configuration
- create LanguageUtil and provider for runtime language switching
- use translation strings in HomeScreen

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac72e708688325b31f6038367864c8